### PR TITLE
Changed manage_repo param from icinga2 to icingaweb2 to include repo

### DIFF
--- a/production/hieradata/node/icinga.yaml
+++ b/production/hieradata/node/icinga.yaml
@@ -1,6 +1,6 @@
 ---
 profiles::alerting::icinga2: true
-profiles::alerting::icinga2::manage_repo: true
+profiles::alerting::icingaweb2::manage_repo: true
 profiles::alerting::icingaweb2: true
 profiles::bootstrap::repos: true
 profiles::bootstrap::repositories::epel: true


### PR DESCRIPTION
The parameter was set to manage_repo in profiles::alerting::icinga2, but that doesn't exist. The correct parameter is profiles::alerting::icinga**web**2::manage_repo. 