### PR TITLE
Bugfix: icingaweb2 failed to install

### DIFF
--- a/production/hieradata/node/icinga.yaml
+++ b/production/hieradata/node/icinga.yaml
@@ -34,3 +34,10 @@ profiles::website::apache::vhosts:
           - '^.*$ index.php [NC,L]'
     setenv:
       - 'ICINGAWEB_CONFIGDIR "/etc/icingaweb2"'
+
+profiles::bootstrap::repositories::repositories:
+  'centos-sclo-rh':
+    baseurl: 'http://mirror.centos.org/centos/7/sclo/$basearch/rh/'
+    enabled: 1
+    gpgcheck: 0
+


### PR DESCRIPTION
This was due to being unable to install the rh-php71-common package.

This was caused by the RH-SCL repository missing.
Fixed by adding with passing it in hiera via profiles::bootstrap::repositories::repositories.

Signed-off-by: bjanssens <bjanssens@inuits.eu>