### PR TITLE
Bugfix: Make the vagrant cmd work from subdirs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,13 @@
 # vi: set ft=ruby :
 
 require 'yaml'
-if File.file?('vagrant.yaml')
-  vagrant_config = YAML.load_file('vagrant.yaml')
-elsif File.file?('vagrant.yaml.dist')
-  vagrant_config = YAML.load_file('vagrant.yaml.dist')
+
+vagrant_root = File.expand_path(File.dirname(__FILE__))
+
+if File.file?(vagrant_root + '/vagrant.yaml')
+  vagrant_config = YAML.load_file(vagrant_root + '/vagrant.yaml')
+elsif File.file?(vagrant_root + '/vagrant.yaml.dist')
+  vagrant_config = YAML.load_file(vagrant_root + '/vagrant.yaml.dist')
 else
   raise "No vagrant config is provided."
 end


### PR DESCRIPTION
When in a subdirectory of the vagrant project the vagrant command fails with the following error:
```
Line number: 10
Message: RuntimeError: No vagrant config is provided.
```
This is due it looking for the vagrant.yaml / vagrant.yaml.dist files in the directory where the vagrant command was issued from.
The solution to this is to get the vagrant_root directory prepended when looking for the files.

Signed-off-by: bjanssens <bjanssens@inuits.eu>